### PR TITLE
tsdb index: introduce scan matchers

### DIFF
--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -111,6 +111,9 @@ type IndexReader interface {
 	// The names returned are sorted.
 	LabelNamesFor(ctx context.Context, postings index.Postings) ([]string, error)
 
+	// IndexLookupPlanner returns the index lookup planner for this reader.
+	IndexLookupPlanner() index.LookupPlanner
+
 	// Close releases the underlying resources of the reader.
 	Close() error
 }
@@ -502,7 +505,7 @@ func (r blockIndexReader) LabelValues(ctx context.Context, name string, hints *s
 		return st, nil
 	}
 
-	return labelValuesWithMatchers(ctx, r.ir, name, hints, matchers...)
+	return labelValuesWithMatchers(ctx, r, name, hints, matchers...)
 }
 
 func (r blockIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Matcher) ([]string, error) {
@@ -510,7 +513,7 @@ func (r blockIndexReader) LabelNames(ctx context.Context, matchers ...*labels.Ma
 		return r.b.LabelNames(ctx)
 	}
 
-	return labelNamesWithMatchers(ctx, r.ir, matchers...)
+	return labelNamesWithMatchers(ctx, r, matchers...)
 }
 
 func (r blockIndexReader) Postings(ctx context.Context, name string, values ...string) (index.Postings, error) {
@@ -558,6 +561,12 @@ func (r blockIndexReader) LabelValueFor(ctx context.Context, id storage.SeriesRe
 // The names returned are sorted.
 func (r blockIndexReader) LabelNamesFor(ctx context.Context, postings index.Postings) ([]string, error) {
 	return r.ir.LabelNamesFor(ctx, postings)
+}
+
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// Block readers use the default index-only planner.
+func (r blockIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
 }
 
 type blockTombstoneReader struct {

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -44,6 +44,7 @@ import (
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 	_ "github.com/prometheus/prometheus/tsdb/goversion" // Load the package into main to make sure minimum Go version is met.
+	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/tsdbutil"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/compression"
@@ -93,6 +94,7 @@ func DefaultOptions() *Options {
 		CompactionDelayMaxPercent:   DefaultCompactionDelayMaxPercent,
 		CompactionDelay:             time.Duration(0),
 		PostingsDecoderFactory:      DefaultPostingsDecoderFactory,
+		IndexLookupPlanner:          &index.OnlyIndexLookupPlanner{},
 	}
 }
 
@@ -222,6 +224,10 @@ type Options struct {
 
 	// UseUncachedIO allows bypassing the page cache when appropriate.
 	UseUncachedIO bool
+
+	// IndexLookupPlanner plans how to execute index lookups by deciding which matchers
+	// to apply during index lookup versus after series retrieval.
+	IndexLookupPlanner index.LookupPlanner
 }
 
 type NewCompactorFunc func(ctx context.Context, r prometheus.Registerer, l *slog.Logger, ranges []int64, pool chunkenc.Pool, opts *Options) (Compactor, error)

--- a/tsdb/db_test.go
+++ b/tsdb/db_test.go
@@ -3052,13 +3052,12 @@ func TestCompactHead(t *testing.T) {
 	dbDir := t.TempDir()
 
 	// Open a DB and append data to the WAL.
-	tsdbCfg := &Options{
-		RetentionDuration: int64(time.Hour * 24 * 15 / time.Millisecond),
-		NoLockfile:        true,
-		MinBlockDuration:  int64(time.Hour * 2 / time.Millisecond),
-		MaxBlockDuration:  int64(time.Hour * 2 / time.Millisecond),
-		WALCompression:    compression.Snappy,
-	}
+	tsdbCfg := DefaultOptions()
+	tsdbCfg.RetentionDuration = int64(time.Hour * 24 * 15 / time.Millisecond)
+	tsdbCfg.NoLockfile = true
+	tsdbCfg.MinBlockDuration = int64(time.Hour * 2 / time.Millisecond)
+	tsdbCfg.MaxBlockDuration = int64(time.Hour * 2 / time.Millisecond)
+	tsdbCfg.WALCompression = compression.Snappy
 
 	db, err := Open(dbDir, promslog.NewNopLogger(), prometheus.NewRegistry(), tsdbCfg, nil)
 	require.NoError(t, err)

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -186,6 +186,9 @@ type HeadOptions struct {
 
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
+
+	// IndexLookupPlanner can be optionally used when querying the index of the Head.
+	IndexLookupPlanner index.LookupPlanner
 }
 
 const (
@@ -207,6 +210,7 @@ func DefaultHeadOptions() *HeadOptions {
 		SeriesCallback:       &noopSeriesLifecycleCallback{},
 		IsolationDisabled:    defaultIsolationDisabled,
 		WALReplayConcurrency: defaultWALReplayConcurrency,
+		IndexLookupPlanner:   &index.ScanEmptyMatchersLookupPlanner{},
 	}
 	ho.OutOfOrderCapMax.Store(DefaultOutOfOrderCapMax)
 	return ho

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -307,6 +307,12 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postin
 	return names, nil
 }
 
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// Head readers use the default index-only planner.
+func (h *headIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
+}
+
 // Chunks returns a ChunkReader against the block.
 func (h *Head) Chunks() (ChunkReader, error) {
 	return h.chunksRange(math.MinInt64, math.MaxInt64, h.iso.State(math.MinInt64, math.MaxInt64))

--- a/tsdb/head_read.go
+++ b/tsdb/head_read.go
@@ -310,7 +310,7 @@ func (h *headIndexReader) LabelNamesFor(ctx context.Context, series index.Postin
 // IndexLookupPlanner returns the index lookup planner for this reader.
 // Head readers use the default index-only planner.
 func (h *headIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	return &index.OnlyIndexLookupPlanner{}
+	return h.head.opts.IndexLookupPlanner
 }
 
 // Chunks returns a ChunkReader against the block.

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -1114,6 +1114,10 @@ type Reader struct {
 	version int
 }
 
+func (r *Reader) IndexLookupPlanner() LookupPlanner {
+	return &OnlyIndexLookupPlanner{}
+}
+
 type postingOffset struct {
 	value string
 	off   int

--- a/tsdb/index/lookup.go
+++ b/tsdb/index/lookup.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// OnlyIndexLookupPlanner implements LookupPlanner by always applying all matchers
+// during index lookup. This maintains current behavior and serves as the default fallback.
+type OnlyIndexLookupPlanner struct{}
+
+func (p *OnlyIndexLookupPlanner) PlanIndexLookup(_ context.Context, matchers []*labels.Matcher, _, _ int64) LookupPlan {
+	return &indexOnlyLookupPlan{matchers: matchers}
+}
+
+// LookupPlanner plans how to execute index lookups by deciding which matchers
+// to apply during index lookup versus after series retrieval.
+type LookupPlanner interface {
+	PlanIndexLookup(ctx context.Context, matchers []*labels.Matcher, minT, maxT int64) LookupPlan
+}
+
+// LookupPlan represents the decision of which matchers to apply during
+// index lookup versus during series scanning.
+type LookupPlan interface {
+	// ScanMatchers returns matchers that should be applied during series scanning
+	ScanMatchers() []*labels.Matcher
+	// IndexMatchers returns matchers that should be applied during index lookup
+	IndexMatchers() []*labels.Matcher
+}
+
+// indexOnlyLookupPlan implements LookupPlan by applying all matchers during index lookup.
+// This maintains the current behavior and serves as the default fallback.
+type indexOnlyLookupPlan struct {
+	matchers []*labels.Matcher
+}
+
+func (p *indexOnlyLookupPlan) ScanMatchers() []*labels.Matcher {
+	return nil
+}
+
+func (p *indexOnlyLookupPlan) IndexMatchers() []*labels.Matcher {
+	return p.matchers
+}

--- a/tsdb/index/lookup.go
+++ b/tsdb/index/lookup.go
@@ -19,14 +19,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-// OnlyIndexLookupPlanner implements LookupPlanner by always applying all matchers
-// during index lookup. This maintains current behavior and serves as the default fallback.
-type OnlyIndexLookupPlanner struct{}
-
-func (p *OnlyIndexLookupPlanner) PlanIndexLookup(_ context.Context, matchers []*labels.Matcher, _, _ int64) LookupPlan {
-	return &indexOnlyLookupPlan{matchers: matchers}
-}
-
 // LookupPlanner plans how to execute index lookups by deciding which matchers
 // to apply during index lookup versus after series retrieval.
 type LookupPlanner interface {
@@ -42,16 +34,51 @@ type LookupPlan interface {
 	IndexMatchers() []*labels.Matcher
 }
 
-// indexOnlyLookupPlan implements LookupPlan by applying all matchers during index lookup.
-// This maintains the current behavior and serves as the default fallback.
-type indexOnlyLookupPlan struct {
-	matchers []*labels.Matcher
+// ScanEmptyMatchersLookupPlanner implements LookupPlanner by deferring empty matchers such as l="", l=~".+" to scan matchers.
+type ScanEmptyMatchersLookupPlanner struct{}
+
+func (p *ScanEmptyMatchersLookupPlanner) PlanIndexLookup(_ context.Context, matchers []*labels.Matcher, _, _ int64) LookupPlan {
+	if len(matchers) <= 1 {
+		// If there is only one matcher, then using the index is usually more efficient.
+		// This also covers test cases which use matchers such as {""=""} or {""=~".*"} to mean "match all series"
+		return &concreteLookupPlan{
+			indexMatchers: matchers,
+		}
+	}
+	var scanMatchers, indexMatchers []*labels.Matcher
+
+	for _, matcher := range matchers {
+		if matcher.Type == labels.MatchRegexp && matcher.Value == ".*" {
+			// This matches everything (empty and arbitrary values), so it doesn't reduce the selectivity of the whole set of matchers.
+			continue
+		}
+		// Put empty string matchers and regex matchers that match everything in scan matchers.
+		// These matchers are unlikely to reduce the selectivity of the matchers, but can still filter out some series, so we can't ignore them.
+		if (matcher.Type == labels.MatchEqual && matcher.Value == "") ||
+			(matcher.Type == labels.MatchRegexp && matcher.Value == ".+") {
+			scanMatchers = append(scanMatchers, matcher)
+		} else {
+			// Use selective matchers in index lookup for better performance
+			indexMatchers = append(indexMatchers, matcher)
+		}
+	}
+
+	return &concreteLookupPlan{
+		indexMatchers: indexMatchers,
+		scanMatchers:  scanMatchers,
+	}
 }
 
-func (p *indexOnlyLookupPlan) ScanMatchers() []*labels.Matcher {
-	return nil
+// concreteLookupPlan implements LookupPlan by storing pre-computed index and scan matchers.
+type concreteLookupPlan struct {
+	indexMatchers []*labels.Matcher
+	scanMatchers  []*labels.Matcher
 }
 
-func (p *indexOnlyLookupPlan) IndexMatchers() []*labels.Matcher {
-	return p.matchers
+func (p *concreteLookupPlan) ScanMatchers() []*labels.Matcher {
+	return p.scanMatchers
+}
+
+func (p *concreteLookupPlan) IndexMatchers() []*labels.Matcher {
+	return p.indexMatchers
 }

--- a/tsdb/index/lookup.go
+++ b/tsdb/index/lookup.go
@@ -63,6 +63,12 @@ func (p *ScanEmptyMatchersLookupPlanner) PlanIndexLookup(_ context.Context, matc
 		}
 	}
 
+	if len(indexMatchers) == 0 {
+		// Zero index matchers match no series. We retain one index matchers so that we have a base set of series which we can scan.
+		indexMatchers = scanMatchers[:1]
+		scanMatchers = scanMatchers[1:]
+	}
+
 	return &concreteLookupPlan{
 		indexMatchers: indexMatchers,
 		scanMatchers:  scanMatchers,

--- a/tsdb/index/lookup.go
+++ b/tsdb/index/lookup.go
@@ -55,7 +55,7 @@ type LookupPlan interface {
 	IndexMatchers() []*labels.Matcher
 }
 
-// NewIndexOnlyLookupPlan creates a new LookupPlan which is based on the
+// NewIndexOnlyLookupPlan creates a new LookupPlan which uses the provided matchers for looking up the index only.
 func NewIndexOnlyLookupPlan(matchers []*labels.Matcher) LookupPlan {
 	return &concreteLookupPlan{indexMatchers: matchers}
 }

--- a/tsdb/index/lookup_test.go
+++ b/tsdb/index/lookup_test.go
@@ -64,13 +64,30 @@ func TestScanEmptyMatchersLookupPlanner(t *testing.T) {
 			expectedScan: []*labels.Matcher{},
 		},
 		{
-			name: "all non-selective matchers go to scan",
+			name: "even with only non-selective matchers, there is still one which stays as index matcher",
 			matchers: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
 				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
 				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
 			},
-			expectedIndex: []*labels.Matcher{},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+			},
+			expectedScan: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+		},
+		{
+			name: "all non-selective matchers go to scan",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+			},
 			expectedScan: []*labels.Matcher{
 				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
 				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),

--- a/tsdb/index/lookup_test.go
+++ b/tsdb/index/lookup_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestOnlyIndexLookupPlanner(t *testing.T) {
+	planner := &OnlyIndexLookupPlanner{}
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+		labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
+	}
+
+	plan := planner.PlanIndexLookup(context.TODO(), matchers, 0, 1000)
+
+	// OnlyIndexLookupPlanner should apply all matchers during index lookup
+	require.Empty(t, plan.ScanMatchers())
+
+	require.Len(t, plan.IndexMatchers(), 2)
+
+	// Verify the matchers are the same
+	indexMatchers := plan.IndexMatchers()
+	for i, matcher := range matchers {
+		require.Equal(t, matcher, indexMatchers[i])
+	}
+}

--- a/tsdb/index/lookup_test.go
+++ b/tsdb/index/lookup_test.go
@@ -143,7 +143,7 @@ func TestScanEmptyMatchersLookupPlanner(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			plan := planner.PlanIndexLookup(context.TODO(), tc.matchers, 0, 1000)
+			plan, _ := planner.PlanIndexLookup(context.TODO(), NewIndexOnlyLookupPlan(tc.matchers), 0, 1000)
 
 			require.Equal(t, matchersToString(tc.expectedScan), matchersToString(plan.ScanMatchers()))
 			require.Equal(t, matchersToString(tc.expectedIndex), matchersToString(plan.IndexMatchers()))

--- a/tsdb/index/lookup_test.go
+++ b/tsdb/index/lookup_test.go
@@ -22,24 +22,128 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-func TestOnlyIndexLookupPlanner(t *testing.T) {
-	planner := &OnlyIndexLookupPlanner{}
+func TestScanEmptyMatchersLookupPlanner(t *testing.T) {
+	planner := &ScanEmptyMatchersLookupPlanner{}
 
-	matchers := []*labels.Matcher{
-		labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
-		labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
+	testCases := []struct {
+		name          string
+		matchers      []*labels.Matcher
+		expectedIndex []*labels.Matcher
+		expectedScan  []*labels.Matcher
+	}{
+		{
+			name: "splits matchers between index and scan",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"), // index
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),   // dropped
+				labels.MustNewMatcher(labels.MatchEqual, "env", ""),           // scan
+				labels.MustNewMatcher(labels.MatchNotEqual, "status", "down"), // index
+				labels.MustNewMatcher(labels.MatchRegexp, "region", ".+"),     // scan
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "status", "down"),
+			},
+			expectedScan: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "env", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "region", ".+"),
+			},
+		},
+		{
+			name: "all selective matchers go to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "instance", "localhost"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", "prod|staging"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "instance", "localhost"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", "prod|staging"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "all non-selective matchers go to scan",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", ".*"),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+			expectedIndex: []*labels.Matcher{},
+			expectedScan: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+				labels.MustNewMatcher(labels.MatchRegexp, "env", ".+"),
+			},
+		},
+		{
+			name: "single matcher goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", "prometheus"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single empty matcher goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "job", ""),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single match-all regex goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "job", ".*"),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchRegexp, "job", ".*"),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name: "single empty matcher goes to index",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "", ""),
+			},
+			expectedIndex: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "", ""),
+			},
+			expectedScan: []*labels.Matcher{},
+		},
+		{
+			name:          "empty matchers slice",
+			matchers:      []*labels.Matcher{},
+			expectedIndex: []*labels.Matcher{},
+			expectedScan:  []*labels.Matcher{},
+		},
 	}
 
-	plan := planner.PlanIndexLookup(context.TODO(), matchers, 0, 1000)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planner.PlanIndexLookup(context.TODO(), tc.matchers, 0, 1000)
 
-	// OnlyIndexLookupPlanner should apply all matchers during index lookup
-	require.Empty(t, plan.ScanMatchers())
-
-	require.Len(t, plan.IndexMatchers(), 2)
-
-	// Verify the matchers are the same
-	indexMatchers := plan.IndexMatchers()
-	for i, matcher := range matchers {
-		require.Equal(t, matcher, indexMatchers[i])
+			require.Equal(t, matchersToString(tc.expectedScan), matchersToString(plan.ScanMatchers()))
+			require.Equal(t, matchersToString(tc.expectedIndex), matchersToString(plan.IndexMatchers()))
+		})
 	}
+}
+
+func matchersToString(matchers []*labels.Matcher) string {
+	if len(matchers) == 0 {
+		return ""
+	}
+	var result string
+	for i, m := range matchers {
+		if i > 0 {
+			result += ","
+		}
+		result += m.String()
+	}
+	return result
 }

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -188,6 +188,12 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 	return labelValuesWithMatchers(ctx, oh, name, hints, matchers...)
 }
 
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// HeadAndOOO readers use the default index-only planner.
+func (oh *HeadAndOOOIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
+}
+
 func lessByMinTimeAndMinRef(a, b chunks.Meta) int {
 	switch {
 	case a.MinTime < b.MinTime:
@@ -510,6 +516,12 @@ func (ir *OOOCompactionHeadIndexReader) LabelNamesFor(_ context.Context, _ index
 
 func (ir *OOOCompactionHeadIndexReader) Close() error {
 	return nil
+}
+
+// IndexLookupPlanner returns the index lookup planner for this reader.
+// OOO compaction head readers use the default index-only planner.
+func (ir *OOOCompactionHeadIndexReader) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
 }
 
 // HeadAndOOOQuerier queries both the head and the out-of-order head.

--- a/tsdb/ooo_head_read.go
+++ b/tsdb/ooo_head_read.go
@@ -191,7 +191,7 @@ func (oh *HeadAndOOOIndexReader) LabelValues(ctx context.Context, name string, h
 // IndexLookupPlanner returns the index lookup planner for this reader.
 // HeadAndOOO readers use the default index-only planner.
 func (oh *HeadAndOOOIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	return &index.OnlyIndexLookupPlanner{}
+	return oh.head.opts.IndexLookupPlanner
 }
 
 func lessByMinTimeAndMinRef(a, b chunks.Meta) int {
@@ -521,7 +521,7 @@ func (ir *OOOCompactionHeadIndexReader) Close() error {
 // IndexLookupPlanner returns the index lookup planner for this reader.
 // OOO compaction head readers use the default index-only planner.
 func (ir *OOOCompactionHeadIndexReader) IndexLookupPlanner() index.LookupPlanner {
-	return &index.OnlyIndexLookupPlanner{}
+	return ir.ch.head.opts.IndexLookupPlanner
 }
 
 // HeadAndOOOQuerier queries both the head and the out-of-order head.

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2413,7 +2413,7 @@ func (m mockIndex) LabelNames(_ context.Context, matchers ...*labels.Matcher) ([
 }
 
 func (m mockIndex) IndexLookupPlanner() index.LookupPlanner {
-	return &index.OnlyIndexLookupPlanner{}
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 func BenchmarkQueryIterator(b *testing.B) {
@@ -3355,7 +3355,7 @@ func (m mockMatcherIndex) PostingsForAllLabelValues(context.Context, string) ind
 }
 
 func (m mockMatcherIndex) IndexLookupPlanner() index.LookupPlanner {
-	return &index.OnlyIndexLookupPlanner{}
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 func TestPostingsForMatcher(t *testing.T) {
@@ -3813,7 +3813,7 @@ func (m mockReaderOfLabels) Symbols() index.StringIter {
 }
 
 func (m mockReaderOfLabels) IndexLookupPlanner() index.LookupPlanner {
-	return &index.OnlyIndexLookupPlanner{}
+	return &index.ScanEmptyMatchersLookupPlanner{}
 }
 
 // TestMergeQuerierConcurrentSelectMatchers reproduces the data race bug from

--- a/tsdb/querier_test.go
+++ b/tsdb/querier_test.go
@@ -2412,6 +2412,10 @@ func (m mockIndex) LabelNames(_ context.Context, matchers ...*labels.Matcher) ([
 	return l, nil
 }
 
+func (m mockIndex) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
+}
+
 func BenchmarkQueryIterator(b *testing.B) {
 	cases := []struct {
 		numBlocks                   int
@@ -3350,6 +3354,10 @@ func (m mockMatcherIndex) PostingsForAllLabelValues(context.Context, string) ind
 	return index.ErrPostings(errors.New("PostingsForAllLabelValues called"))
 }
 
+func (m mockMatcherIndex) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
+}
+
 func TestPostingsForMatcher(t *testing.T) {
 	ctx := context.Background()
 
@@ -3802,6 +3810,10 @@ func (m mockReaderOfLabels) Series(storage.SeriesRef, *labels.ScratchBuilder, *[
 
 func (m mockReaderOfLabels) Symbols() index.StringIter {
 	panic("Series called")
+}
+
+func (m mockReaderOfLabels) IndexLookupPlanner() index.LookupPlanner {
+	return &index.OnlyIndexLookupPlanner{}
 }
 
 // TestMergeQuerierConcurrentSelectMatchers reproduces the data race bug from


### PR DESCRIPTION
> opening against my fork first so that @chencs and @bboreham can review first 

### **Background**

In the Prometheus TSDB, matchers are always used to query the index. There are some cases where skipping those matchers from the index and then applying them on the retrieved series from the block is less resource intensive. 

[This document explores the problem in a bit more detail](https://docs.google.com/document/d/1L2dh93fX-tukz3MeSvtbhcY0wpgqlZUX1G7dnCzizCg)

This is the plan we have in Mimir to solve this: https://github.com/grafana/mimir/issues/11916

### **What this PR does**

#### Interfaces

In this PR I'm introducing the concept of **scan matchers**. Unlike to **index matchers** (aka just "matchers" today), scan matchers are used to filter out series after they have been retrieved from the block.

The core of this PR adds a new method to the `IndexReader`, called `IndexLookupPlanner() index.LookupPlanner`. An `index.LookupPlanner` partitions the matchers into matchers which will be used against the inverted index and matchers which will be used in a sequential scan after retrieving the labels of the matching series.

The `LookupPlanner` is an interface so that in downstream projects can implement their own planners based on their storage characteristics and based on the target performance. They can also chain multiple planners via the `index.ChainLookupPlanners`. 

The `LookupPlan` is currently implemented as an interface because later down the road there will be a need for different kind of plans (e.g. for label names and label values; cost-based vs static).

#### `ScanEmptyMatchersLookupPlanner`

There are some matchers, which are expensive to apply on the inverted index and usually don't end up filtering any data. This PR adds one implementation of `LookupPlanner`: `ScanEmptyMatchersLookupPlanner`, which defers those matchers to scan matchers and removes some matchers when they match literally every possible value, even the unset value.

- `{label=""}` - scan matcher
- `{label=~".+"}` - scan matcher
- `{label=~".*"}` - removed matcher


### **Next steps**

The goal now is to have very basic support for this in Prometheus, which would allow experimentation with different planner algorithms. 

We already have some planner implementation which is based on sketches collected from the head block. This is another building block which we can contribute.